### PR TITLE
Properly load all transitive project dependencies

### DIFF
--- a/src/main/java/de/esoco/gwt/gradle/task/GwtCompileTask.java
+++ b/src/main/java/de/esoco/gwt/gradle/task/GwtCompileTask.java
@@ -89,7 +89,7 @@ public class GwtCompileTask extends AbstractTask {
 
 		final Configuration compileClasspath = project.getConfigurations().getByName(
 			JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME);
-		compileClasspath.getDependencies().withType(ProjectDependency.class, new Action<ProjectDependency>() {
+		compileClasspath.getAllDependencies().withType(ProjectDependency.class, new Action<ProjectDependency>() {
 			@Override
 			public void execute(ProjectDependency dep) {
 				addSourceSet(sources, dep.getDependencyProject(), SourceSet.MAIN_SOURCE_SET_NAME);


### PR DESCRIPTION
The fix I did when this was putnami wasn't _quite_ right.

Transitive project dependencies are not being loaded correctly (at least, in gradle 4.10.2); using getAllDependencies() is necessary to correctly resolve such dependencies.