### PR TITLE
Support specifying a java executable

### DIFF
--- a/src/main/java/de/esoco/gwt/gradle/command/AbstractCommand.java
+++ b/src/main/java/de/esoco/gwt/gradle/command/AbstractCommand.java
@@ -184,6 +184,10 @@ public abstract class AbstractCommand {
 
 						spec.jvmArgs(javaArgs);
 						spec.args(args);
+
+						if (javaOptions.getExecutable() != null) {
+							spec.setExecutable(javaOptions.getExecutable());
+						}
 					}
 				});
 		execResult.assertNormalExitValue().rethrowFailure();

--- a/src/main/java/de/esoco/gwt/gradle/extension/JavaOption.java
+++ b/src/main/java/de/esoco/gwt/gradle/extension/JavaOption.java
@@ -34,9 +34,16 @@ public class JavaOption {
 
 	private boolean envClasspath = false;
 
+	private Object executable;
+
 	public int getDebugPort() {
 
 		return debugPort;
+	}
+
+	public Object getExecutable() {
+
+		return executable;
 	}
 
 	public List<String> getJavaArgs() {
@@ -102,6 +109,11 @@ public class JavaOption {
 	public void setEnvClasspath(boolean envClasspath) {
 
 		this.envClasspath = envClasspath;
+	}
+
+	public void setExecutable(Object executable) {
+
+		this.executable = executable;
 	}
 
 	public void setJavaArgs(String... javaArgs) {


### PR DESCRIPTION
This patch adds support for specifying a different path to the `java` executable than whatever is currently being used to run Gradle itself. This makes it possible to add support for different Gradle [JavaToolchains](https://docs.gradle.org/current/userguide/toolchains.html), and run Gradle with one java version, but build the java sources to a higher version, and presumably invoke GWT also with a higher version (not required for plain client code, but is required for linkers, generators).

Example usage - this would let you run your build in Java 8, but build bytecode for Java 11 (using java 11 lang features, apis), and in any linker/generator in the project, it would still run properly:
```
def java11 = javaToolchains.launcherFor {
  languageVersion = JavaLanguageVersion.of(11)
} as Provider<JavaLauncher>

def gwt = project.extensions.findByType(GwtExtension)

gwt.compile.executable = java11.get().executablePath
gwt.dev.executable = java11.get().executablePath
```

This setup assumes additional configuration like
```
tasks.withType(JavaCompile).configureEach {
  javaCompiler.set java11
  options.release.set 11
}
```  
but is written to be compatible with any String, File, etc being passed in as the executable, in line with how [`JavaExecSpec`](https://docs.gradle.org/current/javadoc/org/gradle/process/ProcessForkOptions.html#setExecutable-java.lang.Object-) will behave. Note that as of Gradle 6.7, the [`JavaExec`](https://docs.gradle.org/current/javadoc/org/gradle/api/tasks/JavaExec.html#getJavaLauncher--) task has the javaLauncher property that can be configured somewhat differently, but this isn't as of 7.2 reflected in `JavaExecSpec` itself, it just passes the JavaLauncher's executable string to it.