### PR TITLE
Workaround for the Jetty file locking problem that prevents GWT compi…

### DIFF
--- a/src/main/resources/stub.jetty-conf.xml
+++ b/src/main/resources/stub.jetty-conf.xml
@@ -19,4 +19,8 @@
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Set name="contextPath">/</Set>
   <Set name="war">__WAR_FILE__</Set>
+  <Call name="setInitParameter">
+    <Arg>org.eclipse.jetty.servlet.Default.useFileMappedBuffer</Arg>
+    <Arg>false</Arg>
+  </Call>
 </Configure>


### PR DESCRIPTION
Workaround for the Jetty file locking problem that prevents GWT compilation from working in super dev mode on Windows.